### PR TITLE
ValidatedValues

### DIFF
--- a/core/src/main/scala/cats/tests/ValidatedValues.scala
+++ b/core/src/main/scala/cats/tests/ValidatedValues.scala
@@ -1,0 +1,20 @@
+package cats.tests
+
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
+import org.scalatest.Assertions.fail
+
+trait ValidatedValues {
+  implicit class ValueForValidated[E, A](result: Validated[E, A]) {
+
+    /**
+     * @return the value of this Validated if it is Valid, else fail the test
+     */
+    def value: A = result match {
+      case Invalid(e) => fail(s"Validation failed with $e")
+      case Valid(a)   => a
+    }
+  }
+}
+object ValidatedValues extends ValidatedValues
+

--- a/core/src/main/scala/cats/tests/ValidatedValues.scala
+++ b/core/src/main/scala/cats/tests/ValidatedValues.scala
@@ -2,17 +2,19 @@ package cats.tests
 
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
-import org.scalatest.Assertions.fail
+import org.scalactic.source.Position
+import org.scalatest.exceptions.TestFailedException
 
 trait ValidatedValues {
-  implicit class ValueForValidated[E, A](result: Validated[E, A]) {
+  implicit class ValueForValidated[E, A](result: Validated[E, A])(implicit pos: Position) {
 
     /**
      * @return the value of this Validated if it is Valid, else fail the test
      */
     def value: A = result match {
-      case Invalid(e) => fail(s"Validation failed with $e")
-      case Valid(a)   => a
+      case Invalid(e: Throwable) => throw new TestFailedException(_ => Some(s"Validation failed"), Some(e), pos)
+      case Invalid(e)            => throw new TestFailedException(_ => Some(s"Validation failed with $e"), None, pos)
+      case Valid(a)              => a
     }
   }
 }

--- a/core/src/main/scala/cats/tests/ValidatedValues.scala
+++ b/core/src/main/scala/cats/tests/ValidatedValues.scala
@@ -12,7 +12,7 @@ trait ValidatedValues {
      * @return the value of this Validated if it is Valid, else fail the test
      */
     def value: A = result match {
-      case Invalid(e: Throwable) => throw new TestFailedException(_ => Some(s"Validation failed"), Some(e), pos)
+      case Invalid(e: Throwable) => throw new TestFailedException(_ => Some("Validation failed"), Some(e), pos)
       case Invalid(e)            => throw new TestFailedException(_ => Some(s"Validation failed with $e"), None, pos)
       case Valid(a)              => a
     }

--- a/core/src/test/scala/cats/tests/BasicTest.scala
+++ b/core/src/test/scala/cats/tests/BasicTest.scala
@@ -1,13 +1,20 @@
 package cats.tests
 
+import cats.data.Validated
 import cats.kernel.laws.discipline.EqTests
+import org.scalatest.exceptions.TestFailedException
 
-class BasicTest extends CatsSuite {
+class BasicTest extends CatsSuite with ValidatedValues {
   checkAll("Int", EqTests[Int].eqv)
 
   test("Equals Checks"){
     val s = ""
     // Using ===
     s === s
+  }
+
+  test("Validated Values") {
+    Validated.valid("foo").value shouldEqual "foo"
+    assertThrows[TestFailedException](Validated.invalid("boom").value)
   }
 }


### PR DESCRIPTION
A `.value` extension method in the style of scalatest `OptionValues` and family.

eg.

```scala
val result: ValidatedNec[String, String] = ???
result.value shouldEqual "Hello world!" 
```